### PR TITLE
diy coverage tool for `_next_request`

### DIFF
--- a/coverage_report.json
+++ b/coverage_report.json
@@ -1,0 +1,26 @@
+{
+  "_get_serialized_fields": [
+    false
+  ],
+  "_next_request": [
+    true,
+    false,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true
+  ],
+  "_process_spider_output": [
+    false
+  ],
+  "func_4": [
+    false
+  ],
+  "func_5": [
+    false
+  ]
+}

--- a/diy_coverage_report.txt
+++ b/diy_coverage_report.txt
@@ -1,0 +1,44 @@
+Coverage report of five functions in Scrapy.
+
+---------------------------------------------
+Function: _get_serialized_fields
+	Branch  1: False
+Function coverage: 0.00%
+---------------------------------------------
+
+---------------------------------------------
+Function: _next_request
+	Branch  1: True
+	Branch  2: False
+	Branch  3: True
+	Branch  4: True
+	Branch  5: True
+	Branch  6: True
+	Branch  7: True
+	Branch  8: True
+	Branch  9: True
+	Branch 10: True
+Function coverage: 90.00%
+---------------------------------------------
+
+---------------------------------------------
+Function: _process_spider_output
+	Branch  1: False
+Function coverage: 0.00%
+---------------------------------------------
+
+---------------------------------------------
+Function: func_4
+	Branch  1: False
+Function coverage: 0.00%
+---------------------------------------------
+
+---------------------------------------------
+Function: func_5
+	Branch  1: False
+Function coverage: 0.00%
+---------------------------------------------
+
+Total coverage: 64.29%
+
+---------------------------------------------

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+
+# File path in the top folder (adjust as needed)
+coverage_file = Path.cwd() / "coverage_report.json"
+
+# Load existing data if the file exists
+with coverage_file.open("r") as f:
+    coverage_data = json.load(f)
+
+with Path.open("diy_coverage_report.txt", "w") as f:
+    f.write("Coverage report of five functions in Scrapy.\n\n")
+    total_coverage_tracker = [0,0]
+    for func,branches in coverage_data.items():
+        f.write("-"*45 + "\n")
+        f.write(f"Function: {func}\n")
+        for num,branch in enumerate(branches):
+            f.write(f"\tBranch {num+1:>2}: {branch}\n")
+        covered_branches = branches.count(True)
+        total_branches = len(branches)
+        f.write(f"Function coverage: {(covered_branches / total_branches) * 100:.2f}%\n")
+        f.write("-"*45 + "\n\n")
+        total_coverage_tracker[0] += covered_branches
+        total_coverage_tracker[1] += total_branches
+    f.write(f"Total coverage: {(total_coverage_tracker[0] / total_coverage_tracker[1]) * 100:.2f}%\n\n")
+    f.write("-"*45)
+    
+print(f"Coverage data written to diy_coverage_report.txt.")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,8 @@ tests: this package contains all Scrapy unittests
 see https://docs.scrapy.org/en/latest/contributing.html#running-tests
 """
 
+import atexit
+import json
 import os
 import socket
 from pathlib import Path
@@ -30,3 +32,48 @@ except socket.gaierror:
 def get_testdata(*paths: str) -> bytes:
     """Return test data"""
     return Path(tests_datadir, *paths).read_bytes()
+
+
+# initialize coverage_data to keep track of branch coverage
+coverage_data = {
+    "_get_serialized_fields": [False],
+    "_next_request": [False],
+    "run": [False],
+    "func_4": [False],
+    "func_5": [False],
+}
+
+
+def output_coverage_data():
+    # File path in the top folder (adjust as needed)
+    coverage_file = Path.cwd() / "coverage_report.json"
+
+    # Load existing data if the file exists
+    if coverage_file.exists():
+        try:
+            with coverage_file.open("r") as f:
+                previous_coverage = json.load(f)
+        except json.JSONDecodeError:
+            previous_coverage = {}
+    else:
+        previous_coverage = {}
+
+    # Merge the new data with the existing data
+    for func, branches in coverage_data.items():
+        if func in previous_coverage:
+            prev_branches = previous_coverage[func]
+            merged = []
+            for i, new_flag in enumerate(branches):
+                old_flag = prev_branches[i] if i < len(prev_branches) else False
+                merged.append(new_flag or old_flag)
+            previous_coverage[func] = merged
+        else:
+            previous_coverage[func] = branches
+
+    # Write the merged data back to the file
+    with coverage_file.open("w") as f:
+        json.dump(previous_coverage, f, indent=2)
+
+
+# Register output_coverage_data to run when the program exits
+atexit.register(output_coverage_data)


### PR DESCRIPTION
Added diy branch coverage analysis for `_next_request`.

For some reason adding the flags into the function makes a couple of tests fail. All tests still run and the coverage of `_next_requests` is the same as generated by coverage.py.

Hade some trouble with the __init__ in tests running multiple times, generating the output mulitple times and disrupting the tests so added a temporary json file to keep track of the flags. Run `report_generator.py` to create a better looking report.